### PR TITLE
Adding jupyter-collaboration and jupyter-link-share

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+# jupyter extensions
+jupyterlab-link-share==0.3.0
+jupyter-collaboration==4.1.1
+# ogs
 ogs==6.5.5
 ogstools[pinned]==0.7.0
 # binder requirements


### PR DESCRIPTION
Collaboration in py-percent notebooks does not work yet: https://github.com/mwouts/jupytext/issues/1432.

Work-around: Pair .py-Notebook with .ipynb notebook.